### PR TITLE
Fix filter_timer_countdown causing 'OverflowError: int too big to convert'

### DIFF
--- a/ecoventv2/__init__.py
+++ b/ecoventv2/__init__.py
@@ -677,8 +677,8 @@ class Fan(object):
 
     @filter_timer_countdown.setter
     def filter_timer_countdown(self, input ):
-        val = int(input,16).to_bytes(3,'big')
-        self._filter_timer_countdown = str ( val[2] ) + "d " +str ( val[1] ) + "h " + str ( val[0] ) + "m " 
+        val = int(input,16).to_bytes(4,'big')
+        self._filter_timer_countdown = str ( val[3] * 256 + val[2] ) + "d " +str ( val[1] ) + "h " + str ( val[0] ) + "m " 
 
     @property
     def boost_time (self):


### PR DESCRIPTION
I have a Flexit Roomie V2, which is a rebranded Vento Expert Duo.

I can not add this fan to HomeAssistant as I get an error during setup (IP and password provided by me, broadcasting does not seem to work).

Without this patch I get:
```
Decimal value: 12084800
Traceback (most recent call last):
  File "test.py", line 27, in <module>
    if fan.init_device():
  File "/home/cyberwizzard/pyEcoventV2/ecoventv2/__init__.py", line 231, in init_device
    return self.update()
  File "/home/cyberwizzard/pyEcoventV2/ecoventv2/__init__.py", line 376, in update
    return self.do_func(self.func['read'], request)
  File "/home/cyberwizzard/pyEcoventV2/ecoventv2/__init__.py", line 365, in do_func
    self.parse_response(response)
  File "/home/cyberwizzard/pyEcoventV2/ecoventv2/__init__.py", line 483, in parse_response
    setattr ( self, self.params[int(response[:2].hex(),16)][0], response[2:].hex())
  File "/home/cyberwizzard/pyEcoventV2/ecoventv2/__init__.py", line 681, in filter_timer_countdown
    val = int(input,16).to_bytes(3,'big')
OverflowError: int too big to convert
```

Dump from the test script after applying this patch:
```
state: on
speed: high
boost_status: off
timer_mode: off
timer_counter: 0h 0m 0s
humidity_sensor_state: off
relay_sensor_state: on
analogV_sensor_state: off
humidity_treshold: 70
battery_voltage: 3062 mV
humidity: 53
analogV: 0
relay_status: off
man_speed: 3
fan1_speed: 3300
fan2_speed: 3300
filter_timer_countdown: 72d 8h 17m
boost_time: 30 m
rtc_time: 15h 49m 31s
rtc_date: 1 2017-09-18
device_search: 0034003454XXXXXX
device_password: bananas
machine_hours: 17d 15h 42m
alarm_status: no
cloud_server_state: on
firmware: 0.8 2023-11-04
filter_replacement_status: off
curent_wifi_ip: 192.168.0.38
airflow: ventilation
analogV_treshold: 50
unit_type: Vento Expert Duo A30-1 W V.2
night_mode_timer: 08h 00m
party_mode_timer: 04h 00m
humidity_status: off
analogV_status: off
```