### PR TITLE
Support Blauberg Vento inHome S11 W

### DIFF
--- a/ecoventv2/__init__.py
+++ b/ecoventv2/__init__.py
@@ -87,7 +87,8 @@ class Fan(object):
                     0x0300: 'Vento Expert A50-1/A85-1/A100-1 W V.2', 
                     0x0400: 'Vento Expert Duo A30-1 W V.2', 
                     0x0500: 'Vento Expert A30 W V.2', 
-                    0x1100: 'Vents Breezy 160-E' 
+                    0x1100: 'Vents Breezy 160-E',
+                    0x1B00: 'Vento inHome S11 W'
     }
 
     wifi_operation_modes = {


### PR DESCRIPTION
Add Unit Type 0x1B00 to support Blauberg Vento inHome S11 W

I have tested it on my system without any problems.

https://blaubergventilatoren.de/product/vento-inhome-w