### PR TITLE
[codex] Harden EcoVent V2 protocol handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Python3 library for single-room energy recovery ventilators from Vents / Blauber
 	pip3 install pyEcoventV2
 
 ## Example usage
-	from ecovent import Fan
+	from ecoventv2 import Fan
 	""" Create a new fan with IP Address """
-	""" The Fan object takes 'host', 'name', 'port' as arguments """
+	""" The Fan object takes 'host', 'password', 'fan_id', 'name', 'port' as arguments """
 	""" 'host' (IP address) is the only mandatory argument """
 	""" 'name' is optional and will default to ecofan """
-	""" 'port' is also optional and will default to 4000 """"
+	""" 'port' is also optional and will default to 4000 """
 	fan=Fan("192.168.0.22")
 	
-	""" Optinally create a Fan with a name  
-	fan=Fan("192.168.0.22", "Cellar Fan")
+	""" Optionally create a Fan with a name """
+	fan=Fan("192.168.0.22", name="Cellar Fan")
 
 	""" Update the current values of the fan """
 	fan.update()
@@ -51,8 +51,8 @@ The intended usage of this library is to include ventilation fans from Vents / B
 This library has only been tested on the following fans:
 - [Twinfresh Expert RW1-50](http://vents-us.com/item/5262/VENTS_TwinFresh_Expert_RW1-50-2_Wi-Fi/)
 - [Blauberg VENTO Expert A50-1 W](https://blaubergventilatoren.de/en/product/vento-expert-a50-1-w)
-- [Blauberg VENTO Expert A50-1 W](https://blaubergventilatoren.de/en/product/vento-expert-a50-1-w)
 - [Blauberg VENTO EXPERT DUO A30-1 W](https://blaubergventilatoren.de/en/series/vento-expert-duo-a30-1-s10-w-v2)
+- TwinFresh Style Wifi V.2 / Oxxify smart 50
 
 Fans from Flexit are identical and should work, but this is not yet tested:
 - [Single room ventilator Roomie Dual](https://www.flexit.no/en/products/single_room_ventilator/single_room_ventilator_roomie_dual/single_room_ventilator_roomie_dual/)

--- a/ecoventv2/__init__.py
+++ b/ecoventv2/__init__.py
@@ -1,176 +1,134 @@
-""" Version  """
-__version__ = "0.9.26"
+"""Library to handle communication with Wi-Fi ecofans from TwinFresh/Blauberg."""
 
-"""Library to handle communication with Wifi ecofan from TwinFresh / Blauberg"""
+import math
 import socket
 import sys
-import time
-import asyncio
-import math
+
 # from homeassistant.core import HomeAssistant
+
+__version__ = "0.9.26"
+
 
 class Fan(object):
     """Class to communicate with the ecofan"""
 
-    HEADER = f'FDFD'
+    HEADER = "FDFD"
+    HEADER_BYTES = bytes.fromhex(HEADER)
 
     func = {
-        'read': "01",
-        'write': "02",
-        'write_return': "03",
-        'inc': "04",
-        'dec': "05",
-        'resp': "06"
+        "read": "01",
+        "write": "02",
+        "write_return": "03",
+        "inc": "04",
+        "dec": "05",
+        "resp": "06",
     }
 
-    states = {
-        0: 'off',
-        1: 'on' ,
-        2: 'togle'
-    }
+    states = {0: "off", 1: "on", 2: "togle"}
 
-    speeds = {
-         0: 'standby',
-         1: 'low',
-         2: 'medium',
-         3: 'high',
-         0xff: 'manual'
-    }
+    speeds = {0: "standby", 1: "low", 2: "medium", 3: "high", 0xFF: "manual"}
 
-    timer_modes = {
-        0: 'off',
-        1: 'night',
-        2: 'party'
-    }
+    timer_modes = {0: "off", 1: "night", 2: "party"}
 
-    statuses = {
-        0: 'off',
-        1: 'on'
-    }
+    statuses = {0: "off", 1: "on"}
 
-    boost_statuses = {
-        0: 'off',
-        1: 'on',
-        2: 'delay'
-    }
+    boost_statuses = {0: "off", 1: "on", 2: "delay"}
 
-    airflows = {
-        0: 'ventilation',
-        1: 'heat_recovery',
-        2: 'air_supply',
-        3: 'something'
-    }
+    airflows = {0: "ventilation", 1: "heat_recovery", 2: "air_supply", 3: "something"}
 
-    alarms = {
-        0: 'no',
-        1: 'alarm',
-        2: 'warning'
-    }
+    alarms = {0: "no", 1: "alarm", 2: "warning"}
 
     days_of_week = {
-        0: 'all days',
-        1: 'Monday',
-        2: 'Tuesday',
-        3: 'Wednesday',
-        4: 'Thursday',
-        5: 'Friday',
-        6: 'Saturday',
-        7: 'Sunday',
-        8: 'Mon-Fri',
-        9: 'Sat-Sun',
+        0: "all days",
+        1: "Monday",
+        2: "Tuesday",
+        3: "Wednesday",
+        4: "Thursday",
+        5: "Friday",
+        6: "Saturday",
+        7: "Sunday",
+        8: "Mon-Fri",
+        9: "Sat-Sun",
     }
 
-    filters = {
-        0: 'filter replacement not required' ,
-        1: 'replace filter'
-    }
+    filters = {0: "filter replacement not required", 1: "replace filter"}
 
     unit_types = {
-                    0x0300: 'Vento Expert A50-1/A85-1/A100-1 W V.2',
-                    0x0400: 'Vento Expert Duo A30-1 W V.2',
-                    0x0500: 'Vento Expert A30 W V.2',
-                    0x0E00: 'TwinFresh Style Wifi V.2',
-                    0x1100: 'Vents Breezy 160-E',
-                    0x1B00: 'Vento inHome S11 W'
+        0x0300: "Vento Expert A50-1/A85-1/A100-1 W V.2",
+        0x0400: "Vento Expert Duo A30-1 W V.2",
+        0x0500: "Vento Expert A30 W V.2",
+        0x0E00: "TwinFresh Style Wifi V.2 / Oxxify smart 50",
+        0x1100: "Vents Breezy 160-E",
+        0x1B00: "Vento inHome S11 W",
     }
 
-    wifi_operation_modes = {
-        1: 'client' ,
-        2: 'ap'
-    }
+    wifi_operation_modes = {1: "client", 2: "ap"}
 
-    wifi_enc_types =  {
-            48: 'Open',
-            50: 'wpa-psk' ,
-            51: 'wpa2_psk',
-            52: 'wpa_wpa2_psk'
-    }
+    wifi_enc_types = {48: "Open", 50: "wpa-psk", 51: "wpa2_psk", 52: "wpa_wpa2_psk"}
 
-    wifi_dhcps = {
-        0: 'STATIC',
-        1: 'DHCP',
-        2: 'Invert'
-    }
+    wifi_dhcps = {0: "STATIC", 1: "DHCP", 2: "Invert"}
 
     params = {
-        0x0001: [ 'state', states ],
-        0x0002: [ 'speed', speeds ],
-        0x0006: [ 'boost_status', statuses ],
-        0x0007: [ 'timer_mode', timer_modes ],
-        0x000b: [ 'timer_counter', None ],
-        0x000f: [ 'humidity_sensor_state', states ],
-        0x0014: [ 'relay_sensor_state', states ],
-        0x0016: [ 'analogV_sensor_state', states ],
-        0x0019: [ 'humidity_treshold', None ],
-        0x0024: [ 'battery_voltage', None ],
-        0x0025: [ 'humidity', None ],
-        0x002d: [ 'analogV', None ],
-        0x0032: [ 'relay_status', statuses ],
-        0x0044: [ 'man_speed', None ],
-        0x004a: [ 'fan1_speed', None ],
-        0x004b: [ 'fan2_speed', None ],
-        0x0064: [ 'filter_timer_countdown', None ],
-        0x0066: [ 'boost_time', None ],
-        0x006f: [ 'rtc_time', None ],
-        0x0070: [ 'rtc_date', None ],
-        0x007c: [ 'device_search', None ],
-        0x007d: [ 'device_password', None ],
-        0x007e: [ 'machine_hours', None ],
-        0x0081: [ 'heater_status', statuses ],
-        0x0083: [ 'alarm_status', alarms ],
-        0x0085: [ 'cloud_server_state', states ],
-        0x0086: [ 'firmware', None ],
-        0x0088: [ 'filter_replacement_status', statuses ],
-        0x00a3: [ 'curent_wifi_ip', None ],
-        0x00b7: [ 'airflow' , airflows ],
-        0x00b8: [ 'analogV_treshold', None ],
-        0x00b9: [ 'unit_type', unit_types ],
-        0x0302: [ 'night_mode_timer', None ],
-        0x0303: [ 'party_mode_timer', None ],
-        0x0304: [ 'humidity_status', statuses ],
-        0x0305: [ 'analogV_status', statuses ],
-        0x0306: [ 'beeper', statuses ],
+        0x0001: ["state", states],
+        0x0002: ["speed", speeds],
+        0x0006: ["boost_status", statuses],
+        0x0007: ["timer_mode", timer_modes],
+        0x000B: ["timer_counter", None],
+        0x000F: ["humidity_sensor_state", states],
+        0x0014: ["relay_sensor_state", states],
+        0x0016: ["analogV_sensor_state", states],
+        0x0019: ["humidity_treshold", None],
+        0x0024: ["battery_voltage", None],
+        0x0025: ["humidity", None],
+        0x002D: ["analogV", None],
+        0x0032: ["relay_status", statuses],
+        0x0044: ["man_speed", None],
+        0x004A: ["fan1_speed", None],
+        0x004B: ["fan2_speed", None],
+        0x0063: ["filter_timer_setting", None],
+        0x0064: ["filter_timer_countdown", None],
+        0x0066: ["boost_time", None],
+        0x006F: ["rtc_time", None],
+        0x0070: ["rtc_date", None],
+        0x007C: ["device_search", None],
+        0x007D: ["device_password", None],
+        0x007E: ["machine_hours", None],
+        0x0081: ["heater_status", statuses],
+        0x0083: ["alarm_status", alarms],
+        0x0085: ["cloud_server_state", states],
+        0x0086: ["firmware", None],
+        0x0088: ["filter_replacement_status", statuses],
+        0x00A3: ["curent_wifi_ip", None],
+        0x00B7: ["airflow", airflows],
+        0x00B8: ["analogV_treshold", None],
+        0x00B9: ["unit_type", unit_types],
+        0x0302: ["night_mode_timer", None],
+        0x0303: ["party_mode_timer", None],
+        0x0304: ["humidity_status", statuses],
+        0x0305: ["analogV_status", statuses],
+        0x0306: ["beeper", statuses],
         # Write only parameters
-        0x0065: [ 'filter_timer_reset', None ],		# WRITE ONLY
-        0x0072: [ 'weekly_schedule_state', states ],
-        0x0077: [ 'weekly_schedule_setup', None ],
-        0x0080: [ 'reset_alarms', None ],	# WRITE ONLY
-#        0x0087: [ 'factory_reset', None ],
-#        0x00a0: [ 'wifi_apply_and_quit', None ],
-#        0x00a2: [ 'wifi_discard_and_quit', None ],
-        0x0094: [ 'wifi_operation_mode', wifi_operation_modes ],
-        0x0095: [ 'wifi_name' , None ],
-        0x0096: [ 'wifi_pasword', None ],
-        0x0099: [ 'wifi_enc_type', wifi_enc_types ],
-        0x009a: [ 'wifi_freq_chnnel', None ],
-        0x009b: [ 'wifi_dhcp', wifi_dhcps  ],
-        0x009c: [ 'wifi_assigned_ip', None ],
-        0x009d: [ 'wifi_assigned_netmask', None ],
-        0x009e: [ 'wifi_main_gateway', None ],
+        0x0065: ["filter_timer_reset", None],  # WRITE ONLY
+        0x0072: ["weekly_schedule_state", states],
+        0x0077: ["weekly_schedule_setup", None],
+        0x0080: ["reset_alarms", None],  # WRITE ONLY
+        #        0x0087: [ 'factory_reset', None ],
+        #        0x00a0: [ 'wifi_apply_and_quit', None ],
+        #        0x00a2: [ 'wifi_discard_and_quit', None ],
+        0x0094: ["wifi_operation_mode", wifi_operation_modes],
+        0x0095: ["wifi_name", None],
+        0x0096: ["wifi_pasword", None],
+        0x0099: ["wifi_enc_type", wifi_enc_types],
+        0x009A: ["wifi_freq_chnnel", None],
+        0x009B: ["wifi_dhcp", wifi_dhcps],
+        0x009C: ["wifi_assigned_ip", None],
+        0x009D: ["wifi_assigned_netmask", None],
+        0x009E: ["wifi_main_gateway", None],
     }
+    WRITE_ONLY_PARAMS = {0x0065, 0x0080}
 
     _name = None
-    _host= None
+    _host = None
     _port = None
     _id = None
     _password = None
@@ -191,6 +149,7 @@ class Fan(object):
     _man_speed = None
     _fan1_speed = None
     _fan2_speed = None
+    _filter_timer_setting = None
     _filter_timer_countdown = None
     _boost_time = None
     _rtc_time = None
@@ -223,7 +182,14 @@ class Fan(object):
     _analogV_status = None
     _beeper = None
 
-    def __init__(self, host, password="1111", fan_id="DEFAULT_DEVICEID", name="ecofanv2", port=4000 ):
+    def __init__(
+        self,
+        host,
+        password="1111",
+        fan_id="DEFAULT_DEVICEID",
+        name="ecofanv2",
+        port=4000,
+    ):
         self._name = name
         self._host = host
         self._port = port
@@ -231,40 +197,54 @@ class Fan(object):
         self._id = fan_id
         self._pwd_size = 0
         self._password = password
+        self._unknown_params = {}
+        self.socket = None
 
-    def init_device (self):
+    def init_device(self):
         if self._id == "DEFAULT_DEVICEID":
-            self.get_param( 'device_search' )
+            self.get_param("device_search")
             self._id = self.device_search
         if not self._id:
             return False
         return self.update()
 
-    def search_devices (self, addr = "0.0.0.0", port = 4000 ):
-        payload="FDFD021044454641554c545f44455649434549440431313131017cf805"
+    def search_devices(self, addr="0.0.0.0", port=4000):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.bind((addr, port))
-        sock.settimeout(0.5)
-        ips = []
-        i = 10
-        while ( i > 1 ):
-            i = i - 1
-            self._device_search = self._id
-            if self._host is None:
-                self._host = '<broadcast>'
-            if self._port is None:
-                self._port = port
-            sock.sendto( bytes.fromhex(payload), (self._host, self._port))
-            data, addr = sock.recvfrom(1024)
-            self.parse_response(data)
-            if self._device_search != "DEFAULT_DEVICEID":
-                ips.append(addr[0])
-                ips=list(set(ips))
-            # time.sleep(0.1)
-        sock.close()
-        return ips
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.bind((addr, port))
+            sock.settimeout(0.5)
+            ips = []
+            target_host = self._host or "<broadcast>"
+            target_port = self._port or port
+            payload = bytes.fromhex(
+                self.build_packet(
+                    self.func["read"] + self.encode_params("007c"),
+                    fan_id="DEFAULT_DEVICEID",
+                )
+            )
+            i = 10
+            while i > 1:
+                i = i - 1
+                self._device_search = self._id
+                try:
+                    sock.sendto(payload, (target_host, target_port))
+                    data, addr = sock.recvfrom(1024)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    continue
+                if (
+                    self.parse_response(data)
+                    and self._device_search != "DEFAULT_DEVICEID"
+                ):
+                    ips.append(addr[0])
+                    ips = list(set(ips))
+                # time.sleep(0.1)
+            return ips
+        finally:
+            sock.close()
 
     def connect(self):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -280,99 +260,129 @@ class Fan(object):
                 self.socket.close()
                 return None
 
-    def str2hex(self,str_msg):
+    def str2hex(self, str_msg):
         return "".join("{:02x}".format(ord(c)) for c in str_msg)
 
-    def hex2str(self,hex_msg):
-        return "".join( chr(int("0x" + hex_msg[i:(i+2)],16)) for i in range(0,len(hex_msg),2))
+    def hex2str(self, hex_msg):
+        return "".join(
+            chr(int("0x" + hex_msg[i : (i + 2)], 16)) for i in range(0, len(hex_msg), 2)
+        )
 
-    def hexstr2tuple(self,hex_msg):
-        return [int(hex_msg[i:(i+2)], 16) for i in range(0,len(hex_msg), 2)]
+    def hexstr2tuple(self, hex_msg):
+        return [int(hex_msg[i : (i + 2)], 16) for i in range(0, len(hex_msg), 2)]
 
-    def chksum(self,hex_msg):
-        checksum = hex(sum(self.hexstr2tuple(hex_msg))).replace("0x","").zfill(4)
-        byte_array = bytearray.fromhex(checksum)
-        chksum = hex(byte_array[1]).replace("0x","").zfill(2) + hex(byte_array[0]).replace("0x","").zfill(2)
-        return f"{chksum}"
+    def chksum(self, hex_msg):
+        checksum = sum(self.hexstr2tuple(hex_msg)) & 0xFFFF
+        return f"{checksum & 0xFF:02x}{checksum >> 8:02x}"
 
-    def get_size(self,str):
-        return hex(len(str)).replace("0x","").zfill(2)
+    def get_size(self, str):
+        return hex(len(str)).replace("0x", "").zfill(2)
 
-    def get_header(self):
-        id_size = self.get_size(self._id)
-        pwd_size = self.get_size (self._password)
-        id = self.str2hex(self._id)
-        password = self.str2hex(self._password)
-        str = f"{self._type}{id_size}{id}{pwd_size}{password}"
+    def get_header(self, fan_id=None, password=None, packet_type=None):
+        fan_id = self._id if fan_id is None else fan_id
+        password = self._password if password is None else password
+        packet_type = self._type if packet_type is None else packet_type
+        id_size = self.get_size(fan_id)
+        pwd_size = self.get_size(password)
+        id = self.str2hex(fan_id)
+        password = self.str2hex(password)
+        str = f"{packet_type}{id_size}{id}{pwd_size}{password}"
         return str
 
+    def build_packet(self, data, fan_id=None, password=None, packet_type=None):
+        payload = (
+            self.get_header(fan_id=fan_id, password=password, packet_type=packet_type)
+            + data
+        )
+        return self.HEADER + payload + self.chksum(payload)
+
+    def validate_packet(self, data):
+        if not isinstance(data, (bytes, bytearray)):
+            return False
+        if len(data) < 24:
+            return False
+        if bytes(data[:2]) != self.HEADER_BYTES:
+            return False
+        checksum = int.from_bytes(data[-2:], byteorder="little", signed=False)
+        payload_sum = sum(data[2:-2]) & 0xFFFF
+        return checksum == payload_sum
+
     def get_params_index(self, value):
-        for i in ( self.params ):
+        for i in self.params:
             if self.params[i][0] == value:
                 return i
 
-    def get_params_values(self, idx, value ):
+    def get_params_values(self, idx, value):
         # print ( "EcoventV2: " + idx,  file = sys.stderr )
         index = self.get_params_index(idx)
-        if index != None:
-            if self.params[index][1] != None:
-                for i in (self.params[index][1]):
+        if index is not None:
+            if self.params[index][1] is not None:
+                for i in self.params[index][1]:
                     if self.params[index][1][i] == value:
-                        return [ index , i ]
-            return [ index, None ]
+                        return [index, i]
+            return [index, None]
         else:
-            return [ None, None ]
+            return [None, None]
+
+    def encode_params(self, param, value=""):
+        parameter = ""
+        for i in range(0, len(param), 4):
+            n_out = ""
+            out = param[i : (i + 4)]
+            if out == "0077" and value == "":
+                value = "0101"
+            if value != "":
+                val_bytes = int(len(value) / 2)
+            else:
+                val_bytes = 0
+            if out[:2] != "00":
+                n_out = "ff" + out[:2]
+            if val_bytes > 1:
+                n_out += "fe" + hex(val_bytes).replace("0x", "").zfill(2) + out[2:4]
+            else:
+                n_out += out[2:4]
+            parameter += n_out + value
+            if out == "0077":
+                value = ""
+        return parameter
 
     def send(self, data):
         # print ( "EcoventV2: " + data , file = sys.stderr )
         try:
             self.socket = self.connect()
-            payload = self.get_header() + data
-            payload = self.HEADER + payload + self.chksum(payload)
-            response = self.socket.sendall( bytes.fromhex(payload))
+            if self.socket is None:
+                return None
+            payload = self.build_packet(data)
+            response = self.socket.sendall(bytes.fromhex(payload))
         except socket.timeout:
-            # print ( "EcoventV2: Connection timeout send to device: " + self._host , file = sys.stderr )
+            # print ("EcoventV2: Connection timeout send to device: "
+            #        + self._host, file=sys.stderr)
             return None
-        except OSError:  # this shall include all connection errors like Aborted, Refused and Reset
+        except OSError:
+            # Includes connection errors like Aborted, Refused, and Reset.
             return None
         else:
             return response
 
     def receive(self):
         try:
+            if self.socket is None:
+                return False
             response = self.socket.recv(1024)
         except socket.timeout:
-            # print ( "EcoventV2: Connection timeout receive from device: " + self._host , file = sys.stderr )
-            return ( False )
+            # print ("EcoventV2: Connection timeout receive from device: "
+            #        + self._host, file=sys.stderr)
+            return False
         except OSError:
-            return (False)
+            return False
         else:
             return response
         finally:
-            self.socket.close()
+            if self.socket is not None:
+                self.socket.close()
 
-    def do_func (self, func, param, value="" ):
-        out = ""
-        parameter = ""
-        for i in range (0,len(param), 4):
-            n_out = ""
-            out = param[i:(i+4)] ;
-            if out == "0077" and value =="" :
-                value="0101"
-            if value != "":
-                val_bytes = int(len(value) / 2 ) ;
-            else:
-                val_bytes = 0
-            if out[:2] != "00":
-                n_out = "ff" + out[:2]
-            if val_bytes > 1:
-                n_out += "fe" + hex(val_bytes).replace("0x","").zfill(2) + out[2:4]
-            else:
-                n_out += out[2:4]
-            parameter += n_out  + value
-            if out == "0077":
-                value = ""
-        data = func + parameter
+    def do_func(self, func, param, value=""):
+        data = func + self.encode_params(param, value)
         response = False
         i = 0
         while not response:
@@ -380,10 +390,13 @@ class Fan(object):
             self.send(data)
             response = self.receive()
             if response:
-                self.parse_response(response)
-                return True
+                if self.parse_response(response):
+                    return True
+                response = False
             if i > 10:
-                # print ("EcoventV2: Timeout device: " + self._host + " bail out after " + str(i) + " retries" , file = sys.stderr )
+                # print ("EcoventV2: Timeout device: " + self._host
+                #        + " bail out after " + str(i) + " retries",
+                #        file=sys.stderr)
                 return False
             # await asyncio.sleep(0.1)  # --> needs changing to async functions, ....
             # time.sleep(0.1)
@@ -391,113 +404,137 @@ class Fan(object):
     def update(self):
         request = ""
         for param in self.params:
-            request += hex(param).replace("0x","").zfill(4)
-        return self.do_func(self.func['read'], request)
+            if param in self.WRITE_ONLY_PARAMS:
+                continue
+            request += hex(param).replace("0x", "").zfill(4)
+        return self.do_func(self.func["read"], request)
 
     # async def update_await(self):
     #    return await self._hass.async_add_executor_job(self.update)
 
-    def set_param( self, param, value ):
-        valpar = self.get_params_values (param, value)
+    def set_param(self, param, value):
+        valpar = self.get_params_values(param, value)
         # print ( "EcoventV2: " + " " + param + "/" + value , file = sys.stderr )
-        if valpar[0] !=  None:
-            if valpar[1] != None:
-                self.do_func( self.func['write_return'], hex(valpar[0]).replace("0x","").zfill(4), hex(valpar[1]).replace("0x","").zfill(2) )
+        if valpar[0] is not None:
+            if valpar[1] is not None:
+                self.do_func(
+                    self.func["write_return"],
+                    hex(valpar[0]).replace("0x", "").zfill(4),
+                    hex(valpar[1]).replace("0x", "").zfill(2),
+                )
             else:
-                self.do_func( self.func['write_return'], hex(valpar[0]).replace("0x","").zfill(4), value )
+                self.do_func(
+                    self.func["write_return"],
+                    hex(valpar[0]).replace("0x", "").zfill(4),
+                    value,
+                )
 
-    def get_param( self, param ):
-        idx = self.get_params_index (param)
-        if idx !=  None:
-                self.do_func( self.func['read'], hex(idx).replace("0x","").zfill(4) )
+    def get_param(self, param):
+        idx = self.get_params_index(param)
+        if idx is not None:
+            self.do_func(self.func["read"], hex(idx).replace("0x", "").zfill(4))
 
     # async def get_param_await(self, param):
     #    return await self._hass.async_add_executor_job(self.get_param, param)
 
     def set_state_on(self):
-        request = "0001";
-        value = "01" ;
-        if self.state ==  'off':
-            self.do_func( self.func['write_return'] , request, value )
+        request = "0001"
+        value = "01"
+        if self.state == "off":
+            self.do_func(self.func["write_return"], request, value)
 
     def set_state_off(self):
-        request = "0001";
-        value = "00" ;
-        if self.state ==  'on':
-            self.do_func(self.func['write_return'] , request, value )
+        request = "0001"
+        value = "00"
+        if self.state == "on":
+            self.do_func(self.func["write_return"], request, value)
 
     def set_speed(self, speed):
         if speed >= 1 and speed <= 3:
             request = "0002"
-            value = hex(speed).replace("0x","").zfill(2)
-            self.do_func ( self.func['write_return'], request, value )
+            value = hex(speed).replace("0x", "").zfill(2)
+            self.do_func(self.func["write_return"], request, value)
 
     def set_man_speed_percent(self, speed):
         if speed >= 2 and speed <= 100:
             request = "0044"
             value = math.ceil(255 / 100 * speed)
-            value = hex(value).replace("0x","").zfill(2)
-            self.do_func ( self.func['write_return'], request, value )
-#            request = "0002"
-#            value = "ff"
-#            self.do_func ( self.func['write_return'], request, value )
+            value = hex(value).replace("0x", "").zfill(2)
+            self.do_func(self.func["write_return"], request, value)
+
+    #            request = "0002"
+    #            value = "ff"
+    #            self.do_func ( self.func['write_return'], request, value )
 
     def set_man_speed(self, speed):
         if speed >= 14 and speed <= 255:
             request = "0044"
             value = speed
-            value = hex(value).replace("0x","").zfill(2)
-            self.do_func ( self.func['write_return'], request, value )
-#            request = "0002"
-#            value = "ff"
-#            self.do_func ( self.func['write_return'], request, value )
+            value = hex(value).replace("0x", "").zfill(2)
+            self.do_func(self.func["write_return"], request, value)
+
+    #            request = "0002"
+    #            value = "ff"
+    #            self.do_func ( self.func['write_return'], request, value )
 
     def set_airflow(self, val):
         if val >= 0 and val <= 2:
             request = "00b7"
-            value = hex(val).replace("0x","").zfill(2)
-            self.do_func ( self.func['write_return'], request, value )
+            value = hex(val).replace("0x", "").zfill(2)
+            self.do_func(self.func["write_return"], request, value)
 
-    def parse_response(self,data):
-        pointer = 20 ; # discard header bytes
-        length = len(data) - 2 ;
+    def parse_response(self, data):
+        if not self.validate_packet(data):
+            return False
+        pointer = 2  # discard frame marker
+        length = len(data) - 2
+        if len(data) < pointer + 2:
+            return False
+        pointer += 1  # packet type
+        id_size = data[pointer]
+        pointer += 1
+        if len(data) < pointer + id_size + 3:
+            return False
+        pointer += id_size
         pwd_size = data[pointer]
         pointer += 1
-        password = data[pointer:pwd_size]
+        if len(data) < pointer + pwd_size + 3:
+            return False
         pointer += pwd_size
-        function = data[pointer]
         pointer += 1
         # from here parsing of parameters begin
-        payload=data[pointer:length]
+        payload = data[pointer:length]
         response = bytearray()
         ext_function = 0
         value_counter = 1
         high_byte_value = 0
         parameter = 1
         for p in payload:
-            if parameter and p == 0xff:
-                ext_function = 0xff
+            if parameter and p == 0xFF:
+                ext_function = 0xFF
                 # print ( "def ext:" + hex(0xff) )
-            elif parameter and p == 0xfe:
-                ext_function = 0xfe
+            elif parameter and p == 0xFE:
+                ext_function = 0xFE
                 # print ( "def ext:" + hex(0xfe) )
-            elif parameter and p == 0xfd:
-                ext_function = 0xfd
+            elif parameter and p == 0xFD:
+                ext_function = 0xFD
                 # print ( "dev ext:" + hex(0xfd) )
             else:
-                if ext_function == 0xff:
+                if ext_function == 0xFF:
                     high_byte_value = p
                     ext_function = 1
-                elif ext_function == 0xfe:
+                elif ext_function == 0xFE:
                     value_counter = p
                     ext_function = 2
-                elif ext_function == 0xfd:
-                    None
+                elif ext_function == 0xFD:
+                    ext_function = 0
+                    response = bytearray()
                 else:
-                    if ( parameter == 1 ):
+                    if parameter == 1:
                         # print ("appending: " + hex(high_byte_value))
                         response.append(high_byte_value)
                         parameter = 0
+                        ext_function = 0
                     else:
                         value_counter -= 1
                     response.append(p)
@@ -506,8 +543,34 @@ class Fan(object):
                 parameter = 1
                 value_counter = 1
                 high_byte_value = 0
-                setattr ( self, self.params[int(response[:2].hex(),16)][0], response[2:].hex())
+                ext_function = 0
+                if len(response) < 2:
+                    return False
+                self._store_param(response)
                 response = bytearray()
+        return (
+            ext_function == 0 and parameter == 1 and value_counter == 1 and not response
+        )
+
+    def _store_param(self, response):
+        param_id = int(response[:2].hex(), 16)
+        value = response[2:].hex()
+        if param_id not in self.params:
+            self._unknown_params[param_id] = value
+            return
+        try:
+            setattr(self, self.params[param_id][0], value)
+        except (KeyError, TypeError, ValueError, OverflowError):
+            self._unknown_params[param_id] = value
+
+    def _map_value(self, mapping, value, label):
+        if value in mapping:
+            return mapping[value]
+        return "Unknown %s value %s" % (label, value)
+
+    @property
+    def unknown_params(self):
+        return self._unknown_params
 
     @property
     def name(self):
@@ -559,7 +622,8 @@ class Fan(object):
 
     @state.setter
     def state(self, val):
-        self._state = self.states[int(val)]
+        value = int(val, 16) if isinstance(val, str) else int(val)
+        self._state = self._map_value(self.states, value, "state")
 
     @property
     def speed(self):
@@ -567,8 +631,8 @@ class Fan(object):
 
     @speed.setter
     def speed(self, input):
-        val = int (input, 16 )
-        self._speed = self.speeds[val]
+        val = int(input, 16)
+        self._speed = self._map_value(self.speeds, val, "speed")
 
     @property
     def boost_status(self):
@@ -576,8 +640,8 @@ class Fan(object):
 
     @boost_status.setter
     def boost_status(self, input):
-        val = int (input, 16 )
-        self._boost_status = self.boost_statuses[val]
+        val = int(input, 16)
+        self._boost_status = self._map_value(self.boost_statuses, val, "boost_status")
 
     @property
     def heater_status(self):
@@ -585,8 +649,8 @@ class Fan(object):
 
     @heater_status.setter
     def heater_status(self, input):
-        val = int (input, 16 )
-        self._heater_status = self.heater_status[val]
+        val = int(input, 16)
+        self._heater_status = self._map_value(self.statuses, val, "heater_status")
 
     @property
     def timer_mode(self):
@@ -594,8 +658,8 @@ class Fan(object):
 
     @timer_mode.setter
     def timer_mode(self, input):
-        val = int (input, 16 )
-        self._timer_mode = self.timer_modes[val]
+        val = int(input, 16)
+        self._timer_mode = self._map_value(self.timer_modes, val, "timer_mode")
 
     @property
     def timer_counter(self):
@@ -603,8 +667,10 @@ class Fan(object):
 
     @timer_counter.setter
     def timer_counter(self, input):
-        val = int(input,16).to_bytes(3,'big')
-        self._timer_counter = str ( val[2] ) + "h " +str ( val[1] ) + "m " + str ( val[0] ) + "s "
+        val = int(input, 16).to_bytes(3, "big")
+        self._timer_counter = (
+            str(val[2]) + "h " + str(val[1]) + "m " + str(val[0]) + "s "
+        )
 
     @property
     def humidity_sensor_state(self):
@@ -612,8 +678,10 @@ class Fan(object):
 
     @humidity_sensor_state.setter
     def humidity_sensor_state(self, input):
-        val = int (input, 16 )
-        self._humidity_sensor_state = self.states[val]
+        val = int(input, 16)
+        self._humidity_sensor_state = self._map_value(
+            self.states, val, "humidity_sensor_state"
+        )
 
     @property
     def relay_sensor_state(self):
@@ -621,8 +689,10 @@ class Fan(object):
 
     @relay_sensor_state.setter
     def relay_sensor_state(self, input):
-        val = int (input, 16 )
-        self._relay_sensor_state = self.states[val]
+        val = int(input, 16)
+        self._relay_sensor_state = self._map_value(
+            self.states, val, "relay_sensor_state"
+        )
 
     @property
     def analogV_sensor_state(self):
@@ -630,121 +700,147 @@ class Fan(object):
 
     @analogV_sensor_state.setter
     def analogV_sensor_state(self, input):
-        val = int (input, 16 )
-        self._analogV_sensor_state = self.states[val]
+        val = int(input, 16)
+        self._analogV_sensor_state = self._map_value(
+            self.states, val, "analogV_sensor_state"
+        )
 
     @property
-    def humidity_treshold (self):
+    def humidity_treshold(self):
         return self._humidity_treshold
 
     @humidity_treshold.setter
     def humidity_treshold(self, input):
-        val = int (input, 16 )
-        self._humidity_treshold = str( val )
+        val = int(input, 16)
+        self._humidity_treshold = str(val)
 
     @property
-    def battery_voltage (self):
+    def battery_voltage(self):
         return self._battery_voltage
 
     @battery_voltage.setter
     def battery_voltage(self, input):
-        val = int.from_bytes(int(input,16).to_bytes(2,'big'), byteorder='little', signed=False)
-        self._battery_voltage = str( val ) + " mV"
+        val = int.from_bytes(
+            int(input, 16).to_bytes(2, "big"), byteorder="little", signed=False
+        )
+        self._battery_voltage = str(val) + " mV"
 
     @property
-    def humidity (self):
+    def humidity(self):
         return self._humidity
 
     @humidity.setter
     def humidity(self, input):
-        val = int (input, 16 )
-        self._humidity = str( val )
+        val = int(input, 16)
+        self._humidity = str(val)
 
     @property
-    def analogV (self):
+    def analogV(self):
         return self._analogV
 
     @analogV.setter
     def analogV(self, input):
-        val = int (input, 16 )
-        self._analogV = str( val )
+        val = int(input, 16)
+        self._analogV = str(val)
 
     @property
-    def relay_status (self):
+    def relay_status(self):
         return self._relay_status
 
     @relay_status.setter
     def relay_status(self, input):
-        val = int (input, 16 )
-        self._relay_status = self.statuses[val]
+        val = int(input, 16)
+        self._relay_status = self._map_value(self.statuses, val, "relay_status")
 
     @property
     def man_speed(self):
         return self._man_speed
 
     @man_speed.setter
-    def man_speed(self, input ):
-        val =  int(input,16)
+    def man_speed(self, input):
+        val = int(input, 16)
         if val >= 0 and val <= 255:
-            self._man_speed = int( val / 255 * 100)
+            self._man_speed = int(val / 255 * 100)
 
     @property
     def fan1_speed(self):
         return self._fan1_speed
 
     @fan1_speed.setter
-    def fan1_speed(self, input ):
-        val = int.from_bytes(int(input,16).to_bytes(2,'big'), byteorder='little', signed=False)
-        self._fan1_speed = str ( val )
+    def fan1_speed(self, input):
+        val = int.from_bytes(
+            int(input, 16).to_bytes(2, "big"), byteorder="little", signed=False
+        )
+        self._fan1_speed = str(val)
 
     @property
     def fan2_speed(self):
         return self._fan2_speed
 
     @fan2_speed.setter
-    def fan2_speed(self, input ):
-        val = int.from_bytes(int(input,16).to_bytes(2,'big'), byteorder='little', signed=False)
-        self._fan2_speed = str ( val )
+    def fan2_speed(self, input):
+        val = int.from_bytes(
+            int(input, 16).to_bytes(2, "big"), byteorder="little", signed=False
+        )
+        self._fan2_speed = str(val)
+
+    @property
+    def filter_timer_setting(self):
+        return self._filter_timer_setting
+
+    @filter_timer_setting.setter
+    def filter_timer_setting(self, input):
+        val = int(input, 16).to_bytes(2, "big")
+        self._filter_timer_setting = str(val[1]) + "d " + str(val[0]) + "h "
 
     @property
     def filter_timer_countdown(self):
         return self._filter_timer_countdown
 
     @filter_timer_countdown.setter
-    def filter_timer_countdown(self, input ):
+    def filter_timer_countdown(self, input):
         if len(input) == 8:
             input = input[:-2]
         # print ( "EcoventV2: " + input , file = sys.stderr )
-        val = int(input,16).to_bytes(3,'big')
-        self._filter_timer_countdown = str ( val[2] ) + "d " + str ( val[1] ) + "h " +str ( val[0] ) + "m "
-        # self._filter_timer_countdown = str(int(input[4:6],16)) + "d " + str(int(input[2:4],16)) + "h " +str(int(input[0:2],16)) + "m "
+        val = int(input, 16).to_bytes(3, "big")
+        self._filter_timer_countdown = (
+            str(val[2]) + "d " + str(val[1]) + "h " + str(val[0]) + "m "
+        )
 
     @property
-    def boost_time (self):
+    def boost_time(self):
         return self._boost_time
 
     @boost_time.setter
     def boost_time(self, input):
-        val = int (input, 16 )
-        self._boost_time = str( val ) + " m"
+        val = int(input, 16)
+        self._boost_time = str(val) + " m"
 
     @property
     def rtc_time(self):
         return self._rtc_time
 
     @rtc_time.setter
-    def rtc_time(self, input ):
-        val = int(input,16).to_bytes(3,'big')
-        self._rtc_time = str ( val[2] ) + "h " +str ( val[1] ) + "m " + str ( val[0] ) + "s "
+    def rtc_time(self, input):
+        val = int(input, 16).to_bytes(3, "big")
+        self._rtc_time = str(val[2]) + "h " + str(val[1]) + "m " + str(val[0]) + "s "
 
     @property
     def rtc_date(self):
         return self._rtc_date
 
     @rtc_date.setter
-    def rtc_date(self, input ):
-        val = int(input,16).to_bytes(4,'big')
-        self._rtc_date = str ( val[1] ) + " 20" + str ( val[3] ) + "-" +str ( val[2] ).zfill(2 ) + "-" + str( val[0] ).zfill(2 )
+    def rtc_date(self, input):
+        val = int(input, 16).to_bytes(4, "big")
+        self._rtc_date = (
+            str(val[1])
+            + " 20"
+            + str(val[3])
+            + "-"
+            + str(val[2]).zfill(2)
+            + "-"
+            + str(val[0]).zfill(2)
+        )
 
     @property
     def weekly_schedule_state(self):
@@ -752,7 +848,10 @@ class Fan(object):
 
     @weekly_schedule_state.setter
     def weekly_schedule_state(self, val):
-        self._weekly_schedule_state = self.states[int(val)]
+        value = int(val, 16) if isinstance(val, str) else int(val)
+        self._weekly_schedule_state = self._map_value(
+            self.states, value, "weekly_schedule_state"
+        )
 
     @property
     def weekly_schedule_setup(self):
@@ -760,8 +859,18 @@ class Fan(object):
 
     @weekly_schedule_setup.setter
     def weekly_schedule_setup(self, input):
-        val = int(input,16).to_bytes(6,'big')
-        self._weekly_schedule_setup = self.days_of_week[val[0]] + '/' + str(val[1]) + ': to ' + str(val[5]) + 'h ' + str(val[4]) + 'm ' + self.speeds[val[2]]
+        val = int(input, 16).to_bytes(6, "big")
+        self._weekly_schedule_setup = (
+            self.days_of_week[val[0]]
+            + "/"
+            + str(val[1])
+            + ": to "
+            + str(val[5])
+            + "h "
+            + str(val[4])
+            + "m "
+            + self.speeds[val[2]]
+        )
 
     @property
     def device_search(self):
@@ -784,57 +893,80 @@ class Fan(object):
         return self._machine_hours
 
     @machine_hours.setter
-    def machine_hours(self, input ):
-        val = int(input,16).to_bytes(4,'big')
-        self._machine_hours = str ( int.from_bytes(val[2:3],'big') ) + "d " + str ( val[1] ) + "h " +str ( val[0] ) + "m "
+    def machine_hours(self, input):
+        val = int(input, 16).to_bytes(4, "big")
+        self._machine_hours = (
+            str(int.from_bytes(val[2:3], "big"))
+            + "d "
+            + str(val[1])
+            + "h "
+            + str(val[0])
+            + "m "
+        )
 
     @property
-    def alarm_status (self):
+    def alarm_status(self):
         return self._alarm_status
 
     @alarm_status.setter
     def alarm_status(self, input):
-        val = int (input, 16 )
-        self._alarm_status = self.alarms[val]
+        val = int(input, 16)
+        self._alarm_status = self._map_value(self.alarms, val, "alarm_status")
 
     @property
-    def cloud_server_state (self):
+    def cloud_server_state(self):
         return self._cloud_server_state
 
     @cloud_server_state.setter
     def cloud_server_state(self, input):
-        val = int (input, 16 )
-        self._cloud_server_state = self.states[val]
+        val = int(input, 16)
+        self._cloud_server_state = self._map_value(
+            self.states, val, "cloud_server_state"
+        )
 
     @property
-    def firmware (self):
+    def firmware(self):
         return self._firmware
 
     @firmware.setter
     def firmware(self, input):
-        val = int(input,16).to_bytes(6,'big')
-        self._firmware = str(val[0]) + '.' + str(val[1]) + " " + str(int.from_bytes(val[4:6], byteorder='little', signed=False)) + "-" + str ( val[3] ).zfill(2) + "-" +str ( val[2] ).zfill(2)
+        val = int(input, 16).to_bytes(6, "big")
+        self._firmware = (
+            str(val[0])
+            + "."
+            + str(val[1])
+            + " "
+            + str(int.from_bytes(val[4:6], byteorder="little", signed=False))
+            + "-"
+            + str(val[3]).zfill(2)
+            + "-"
+            + str(val[2]).zfill(2)
+        )
 
     @property
-    def filter_replacement_status (self):
+    def filter_replacement_status(self):
         return self._filter_replacement_status
 
     @filter_replacement_status.setter
     def filter_replacement_status(self, input):
-        val = int (input, 16 )
-        self._filter_replacement_status = self.statuses[val]
+        val = int(input, 16)
+        self._filter_replacement_status = self._map_value(
+            self.statuses, val, "filter_replacement_status"
+        )
 
     @property
-    def wifi_operation_mode (self):
+    def wifi_operation_mode(self):
         return self._wifi_operation_mode
 
     @wifi_operation_mode.setter
     def wifi_operation_mode(self, input):
-        val = int (input, 16 )
-        self._wifi_operation_mode = self.wifi_operation_modes[val]
+        val = int(input, 16)
+        self._wifi_operation_mode = self._map_value(
+            self.wifi_operation_modes, val, "wifi_operation_mode"
+        )
 
     @property
-    def wifi_name (self):
+    def wifi_name(self):
         return self._wifi_name
 
     @wifi_name.setter
@@ -842,7 +974,7 @@ class Fan(object):
         self._wifi_name = self.hex2str(input)
 
     @property
-    def wifi_pasword (self):
+    def wifi_pasword(self):
         return self._wifi_pasword
 
     @wifi_pasword.setter
@@ -850,142 +982,154 @@ class Fan(object):
         self._wifi_pasword = self.hex2str(input)
 
     @property
-    def wifi_enc_type (self):
+    def wifi_enc_type(self):
         return self._wifi_enc_type
 
     @wifi_enc_type.setter
     def wifi_enc_type(self, input):
-        val = int (input, 16 )
-        self._wifi_enc_type = self.wifi_enc_types[val]
+        val = int(input, 16)
+        self._wifi_enc_type = self._map_value(self.wifi_enc_types, val, "wifi_enc_type")
 
     @property
-    def wifi_freq_chnnel (self):
+    def wifi_freq_chnnel(self):
         return self._wifi_freq_chnnel
 
     @wifi_freq_chnnel.setter
     def wifi_freq_chnnel(self, input):
-        val = int (input, 16 )
+        val = int(input, 16)
         self._wifi_freq_chnnel = str(val)
 
     @property
-    def wifi_dhcp (self):
+    def wifi_dhcp(self):
         return self._wifi_dhcp
 
     @wifi_dhcp.setter
     def wifi_dhcp(self, input):
-        val = int (input, 16 )
-        self._wifi_dhcp = self.wifi_dhcps[val]
+        val = int(input, 16)
+        self._wifi_dhcp = self._map_value(self.wifi_dhcps, val, "wifi_dhcp")
 
     @property
-    def wifi_assigned_ip (self):
+    def wifi_assigned_ip(self):
         return self._wifi_assigned_ip
 
     @wifi_assigned_ip.setter
     def wifi_assigned_ip(self, input):
-        val = int(input,16).to_bytes(4,'big')
-        self._wifi_assigned_ip = str(val[0]) + '.' + str(val[1]) + "." + str(val[2]) + "." + str ( val[3] )
+        val = int(input, 16).to_bytes(4, "big")
+        self._wifi_assigned_ip = (
+            str(val[0]) + "." + str(val[1]) + "." + str(val[2]) + "." + str(val[3])
+        )
 
     @property
-    def wifi_assigned_netmask (self):
+    def wifi_assigned_netmask(self):
         return self._wifi_assigned_netmask
 
     @wifi_assigned_netmask.setter
     def wifi_assigned_netmask(self, input):
-        val = int(input,16).to_bytes(4,'big')
-        self._wifi_assigned_netmask = str(val[0]) + '.' + str(val[1]) + "." + str(val[2]) + "." + str ( val[3] )
+        val = int(input, 16).to_bytes(4, "big")
+        self._wifi_assigned_netmask = (
+            str(val[0]) + "." + str(val[1]) + "." + str(val[2]) + "." + str(val[3])
+        )
 
     @property
-    def wifi_main_gateway (self):
+    def wifi_main_gateway(self):
         return self._wifi_main_gateway
 
     @wifi_main_gateway.setter
     def wifi_main_gateway(self, input):
-        val = int(input,16).to_bytes(4,'big')
-        self._wifi_main_gateway = str(val[0]) + '.' + str(val[1]) + "." + str(val[2]) + "." + str ( val[3] )
+        val = int(input, 16).to_bytes(4, "big")
+        self._wifi_main_gateway = (
+            str(val[0]) + "." + str(val[1]) + "." + str(val[2]) + "." + str(val[3])
+        )
 
     @property
-    def curent_wifi_ip (self):
+    def curent_wifi_ip(self):
         return self._curent_wifi_ip
 
     @curent_wifi_ip.setter
     def curent_wifi_ip(self, input):
-        val = int(input,16).to_bytes(4,'big')
-        self._curent_wifi_ip = str(val[0]) + '.' + str(val[1]) + "." + str(val[2]) + "." + str ( val[3] )
+        val = int(input, 16).to_bytes(4, "big")
+        self._curent_wifi_ip = (
+            str(val[0]) + "." + str(val[1]) + "." + str(val[2]) + "." + str(val[3])
+        )
 
     @property
     def airflow(self):
         return self._airflow
 
     @airflow.setter
-    def airflow(self, input ):
-        val = int (input, 16 )
-        self._airflow = self.airflows[val]
+    def airflow(self, input):
+        val = int(input, 16)
+        self._airflow = self._map_value(self.airflows, val, "airflow")
 
     @property
-    def analogV_treshold (self):
+    def analogV_treshold(self):
         return self._analogV_treshold
 
     @analogV_treshold.setter
     def analogV_treshold(self, input):
-        val = int(input,16)
+        val = int(input, 16)
         self._analogV_treshold = str(val)
 
     @property
-    def unit_type (self):
+    def unit_type(self):
         return self._unit_type
 
     @unit_type.setter
     def unit_type(self, input):
-        val = int (input, 16 )
+        val = int(input, 16)
         self._unit_type = self.unit_types.get(val, "Unknown model %s" % val)
 
     @property
-    def night_mode_timer (self):
+    def night_mode_timer(self):
         return self._night_mode_timer
 
     @night_mode_timer.setter
     def night_mode_timer(self, input):
-        val = int(input,16).to_bytes(2,'big')
-        self._night_mode_timer = str(val[1]).zfill(2) + "h " + str(val[0]).zfill(2) + "m"
+        val = int(input, 16).to_bytes(2, "big")
+        self._night_mode_timer = (
+            str(val[1]).zfill(2) + "h " + str(val[0]).zfill(2) + "m"
+        )
 
     @property
-    def party_mode_timer (self):
+    def party_mode_timer(self):
         return self._party_mode_timer
 
     @party_mode_timer.setter
     def party_mode_timer(self, input):
-        val = int(input,16).to_bytes(2,'big')
-        self._party_mode_timer = str(val[1]).zfill(2) + "h " + str(val[0]).zfill(2) + "m"
+        val = int(input, 16).to_bytes(2, "big")
+        self._party_mode_timer = (
+            str(val[1]).zfill(2) + "h " + str(val[0]).zfill(2) + "m"
+        )
 
     @property
-    def humidity_status (self):
+    def humidity_status(self):
         return self._humidity_status
 
     @humidity_status.setter
     def humidity_status(self, input):
-        val = int (input, 16 )
-        self._humidity_status = self.statuses[val]
+        val = int(input, 16)
+        self._humidity_status = self._map_value(self.statuses, val, "humidity_status")
 
     @property
-    def analogV_status (self):
+    def analogV_status(self):
         return self._analogV_status
 
     @analogV_status.setter
     def analogV_status(self, input):
-        val = int (input, 16 )
-        self._analogV_status = self.statuses[val]
+        val = int(input, 16)
+        self._analogV_status = self._map_value(self.statuses, val, "analogV_status")
 
     @property
-    def beeper (self):
+    def beeper(self):
         return self._beeper
 
     @beeper.setter
     def beeper(self, input):
-        val = int (input, 16 )
-        self._beeper = self.statuses[val]
+        val = int(input, 16)
+        self._beeper = self._map_value(self.statuses, val, "beeper")
 
     def reset_filter_timer(self):
-        self.set_param('filter_timer_reset', "")
+        self.set_param("filter_timer_reset", "")
 
-    def reset_alarms (self):
-        self.set_param('reset_alarms', "")
+    def reset_alarms(self):
+        self.set_param("reset_alarms", "")

--- a/setup.py
+++ b/setup.py
@@ -3,29 +3,32 @@ from setuptools import setup
 
 long_description = None
 
-with open("README.md", 'r') as fp:
+with open("README.md", "r") as fp:
     long_description = fp.read()
 
 setup(
-    name = 'pyecoventv2',
-    packages = ['ecovent','ecoventv2'],
-    version='0.9.26',
-    description='Python3 library for single-room energy recovery ventilators from Vents / Blauberg / Flexit',
+    name="pyecoventv2",
+    packages=["ecovent", "ecoventv2"],
+    version="0.9.26",
+    description=(
+        "Python3 library for single-room energy recovery ventilators from "
+        "Vents / Blauberg / Flexit"
+    ),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires='>=3.6.7',
-    author='Aleksander Lehmann',
-    author_email='aleksander@flovik.no',
-    maintainer='Matjaž Godec',
-    maintainer_email = 'matjaz.godec@gmail.com',
-    url='https://github.com/gody0/pyEcoventV2',
+    python_requires=">=3.6.7",
+    author="Aleksander Lehmann",
+    author_email="aleksander@flovik.no",
+    maintainer="Matjaž Godec",
+    maintainer_email="matjaz.godec@gmail.com",
+    url="https://github.com/gody0/pyEcoventV2",
     license="MIT",
     classifiers=[
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Topic :: Home Automation',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-        ]
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Topic :: Home Automation",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
 )

--- a/tests/test_ecoventv2.py
+++ b/tests/test_ecoventv2.py
@@ -1,0 +1,249 @@
+import unittest
+from unittest.mock import patch
+
+from ecoventv2 import Fan
+
+
+def packet_with_payload(payload):
+    body = (
+        bytes([0x02, 0x10]) + b"DEFAULT_DEVICEID" + bytes([0x00, 0x06]) + bytes(payload)
+    )
+    checksum = sum(body) & 0xFFFF
+    return b"\xfd\xfd" + body + checksum.to_bytes(2, byteorder="little")
+
+
+class ParseResponseTest(unittest.TestCase):
+    def test_parse_response_names_shared_oxxify_unit_type(self):
+        fan = Fan("192.0.2.1")
+        fan.parse_response(
+            packet_with_payload(
+                [
+                    0xFE,
+                    0x02,
+                    0xB9,
+                    0x0E,
+                    0x00,
+                ]
+            )
+        )
+        self.assertEqual(fan.unit_type, "TwinFresh Style Wifi V.2 / Oxxify smart 50")
+
+    def test_parse_response_skips_unknown_parameter_ids(self):
+        fan = Fan("192.0.2.1")
+        fan.parse_response(
+            packet_with_payload(
+                [
+                    0xFF,
+                    0x12,
+                    0x34,
+                    0xAB,
+                    0x01,
+                    0x01,
+                ]
+            )
+        )
+        self.assertEqual(fan.unknown_params, {0x1234: "ab"})
+        self.assertEqual(fan.state, "on")
+
+    def test_parse_response_rejects_bad_header_and_checksum(self):
+        fan = Fan("192.0.2.1")
+        good_packet = packet_with_payload([0x01, 0x01])
+        bad_header = b"\x00\x00" + good_packet[2:]
+        bad_checksum = good_packet[:-1] + bytes([good_packet[-1] ^ 0xFF])
+
+        self.assertFalse(fan.parse_response(bad_header))
+        self.assertIsNone(fan.state)
+        self.assertFalse(fan.parse_response(bad_checksum))
+        self.assertIsNone(fan.state)
+
+    def test_parse_response_rejects_short_packet(self):
+        fan = Fan("192.0.2.1")
+        self.assertFalse(fan.parse_response(b"\xfd\xfd"))
+
+    def test_parse_response_keeps_unknown_enum_values(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload(
+                    [
+                        0x02,
+                        0x99,
+                        0x99,
+                        0x31,
+                    ]
+                )
+            )
+        )
+        self.assertEqual(fan.speed, "Unknown speed value 153")
+        self.assertEqual(fan.wifi_enc_type, "Unknown wifi_enc_type value 49")
+
+    def test_parse_response_handles_heater_status(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload(
+                    [
+                        0x81,
+                        0x01,
+                    ]
+                )
+            )
+        )
+        self.assertEqual(fan.heater_status, "on")
+
+    def test_parse_response_reads_filter_timer_setting(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload(
+                    [
+                        0xFE,
+                        0x02,
+                        0x63,
+                        0x02,
+                        0x01,
+                    ]
+                )
+            )
+        )
+        self.assertEqual(fan.filter_timer_setting, "1d 2h ")
+
+    def test_parse_response_rejects_dangling_extended_marker(self):
+        fan = Fan("192.0.2.1")
+        self.assertFalse(fan.parse_response(packet_with_payload([0xFF])))
+
+    def test_parse_response_keeps_known_params_with_bad_value_as_unknown(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload(
+                    [
+                        0xFE,
+                        0x03,
+                        0x24,
+                        0x01,
+                        0x02,
+                        0x03,
+                        0x01,
+                        0x01,
+                    ]
+                )
+            )
+        )
+        self.assertEqual(fan.unknown_params, {0x0024: "010203"})
+        self.assertEqual(fan.state, "on")
+
+    def test_parse_response_skips_no_value_parameter_markers(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload(
+                    [
+                        0xFD,
+                        0x65,
+                        0x01,
+                        0x01,
+                    ]
+                )
+            )
+        )
+        self.assertEqual(fan.unknown_params, {})
+        self.assertEqual(fan.state, "on")
+
+
+class PacketBuilderTest(unittest.TestCase):
+    def test_builds_default_discovery_packet(self):
+        fan = Fan("192.0.2.1")
+        packet = fan.build_packet(
+            fan.func["read"] + fan.encode_params("007c"),
+            fan_id="DEFAULT_DEVICEID",
+        )
+        self.assertEqual(
+            packet.upper(),
+            "FDFD021044454641554C545F44455649434549440431313131017CF805",
+        )
+
+    def test_checksum_wraps_to_16_bits_little_endian(self):
+        fan = Fan("192.0.2.1")
+        payload = "ff" * 300
+        checksum = (0xFF * 300) & 0xFFFF
+        self.assertEqual(fan.chksum(payload), checksum.to_bytes(2, "little").hex())
+
+    def test_encodes_extended_and_multibyte_params(self):
+        fan = Fan("192.0.2.1")
+        self.assertEqual(fan.encode_params("0302"), "ff0302")
+        self.assertEqual(fan.encode_params("00b9", "0e00"), "fe02b90e00")
+        self.assertEqual(fan.encode_params("0302", "0102"), "ff03fe02020102")
+
+    def test_update_does_not_read_write_only_reset_params(self):
+        fan = Fan("192.0.2.1")
+        calls = []
+
+        def do_func(func, param, value=""):
+            calls.append((func, param, value))
+            return True
+
+        fan.do_func = do_func
+        self.assertTrue(fan.update())
+        _, params, _ = calls[0]
+        self.assertNotIn("0065", params)
+        self.assertNotIn("0080", params)
+
+
+class DiscoveryTest(unittest.TestCase):
+    def test_search_devices_times_out_cleanly_without_mutating_host(self):
+        fan = Fan(None)
+
+        class TimeoutSocket:
+            def setsockopt(self, *args):
+                pass
+
+            def bind(self, *args):
+                pass
+
+            def settimeout(self, *args):
+                pass
+
+            def sendto(self, *args):
+                pass
+
+            def recvfrom(self, *args):
+                raise TimeoutError()
+
+            def close(self):
+                self.closed = True
+
+        sock = TimeoutSocket()
+        with patch("socket.socket", return_value=sock):
+            self.assertEqual(fan.search_devices(), [])
+        self.assertIsNone(fan.host)
+
+
+class TransportTest(unittest.TestCase):
+    def test_receive_before_send_returns_false(self):
+        fan = Fan("192.0.2.1")
+        self.assertFalse(fan.receive())
+
+    def test_do_func_retries_invalid_packet_before_success(self):
+        fan = Fan("192.0.2.1")
+        good_packet = packet_with_payload([0x01, 0x01])
+        bad_packet = good_packet[:-1] + bytes([good_packet[-1] ^ 0xFF])
+        responses = [bad_packet, good_packet]
+        sent = []
+
+        def send(data):
+            sent.append(data)
+
+        def receive():
+            return responses.pop(0)
+
+        fan.send = send
+        fan.receive = receive
+
+        self.assertTrue(fan.do_func(fan.func["read"], "0001"))
+        self.assertEqual(len(sent), 2)
+        self.assertEqual(fan.state, "on")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- harden local V2 packet handling with reusable packet building, 16-bit checksum wrapping, dynamic frame header parsing, frame header/checksum validation, and safer discovery timeout cleanup
- keep response parsing tolerant of firmware drift: unknown parameter ids are retained in `Fan.unknown_params`, unknown enum values no longer raise `KeyError`, malformed known values are retained as raw unknown data, and dangling/truncated parameter payloads are rejected
- handle device no-value markers such as `fd65` / `fd80` without corrupting following parameters
- avoid reading write-only reset parameters (`0x0065`, `0x0080`) during normal `update()` polling
- retry after invalid UDP responses instead of treating any truthy response packet as a successful command
- fix the `heater_status` setter crash and add the TwinFresh/Oxxify shared unit type label
- add the app-discovered `0x0063` filter timer setting parameter and regression coverage for packet encoding, checksum, malformed packets, unknown enums, no-value markers, write-only update filtering, discovery timeouts, invalid-response retries, and the live TwinFresh/Oxxify unit type
- refresh README V2 import/example text and tested device list
- run `ruff format` over the touched Python files and keep `ruff`/black-compatible `pycodestyle` clean

## Why

A live TwinFresh Style Wifi V.2 / Oxxify smart 50 device at `192.168.100.9:4000` exposed broader issues than the original narrow unit-type fix:

- newer firmware can return parameter ids or enum values that this library does not know yet, and those should not prevent Home Assistant setup
- the library had no tests around the actual local packet grammar, so checksum/header regressions or malformed UDP responses could silently break state parsing
- the live response showed no-value markers for unsupported or unavailable reads; when the old `update()` also polled write-only reset parameters, the device answered with `fd65`/`fd80`

The reversed official Android app confirms the same packet family used here: `fd fd + payload + checksum16le(sum(payload_bytes))`, with discovery packet `FDFD021044454641554C545F44455649434549440431313131017CF805`.

## Validation

- `python3 -m ruff check ecoventv2/__init__.py tests/test_ecoventv2.py setup.py`
- `python3 -m ruff format --check ecoventv2/__init__.py tests/test_ecoventv2.py setup.py`
- `python3 -m pycodestyle --ignore=E203,W503 --max-line-length=88 ecoventv2/__init__.py tests/test_ecoventv2.py setup.py`
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile ecoventv2/__init__.py ecovent/__init__.py tests/test_ecoventv2.py setup.py`
- live read-only check against device `002D003942435708` at `192.168.100.9:4000`: `update=True`, unit type renders as `TwinFresh Style Wifi V.2 / Oxxify smart 50`, state/speed/airflow/humidity parse successfully, and `unknown_params={}` for the current response
- live raw read confirmed the new `update()` request has 49 params and no longer includes write-only `0065`/`0080`; the corresponding `fd65`/`fd80` no-value replies disappeared from the raw response